### PR TITLE
Removes punctations from componentOrdering string

### DIFF
--- a/Pod/Classes/PIDatePicker.swift
+++ b/Pod/Classes/PIDatePicker.swift
@@ -179,8 +179,14 @@ public class PIDatePicker: UIControl, UIPickerViewDataSource, UIPickerViewDelega
         let firstComponentOrderingString = componentOrdering[componentOrdering.startIndex.advancedBy(0)]
         let lastComponentOrderingString = componentOrdering[componentOrdering.startIndex.advancedBy(componentOrdering.characters.count - 1)]
 
-        let characterSet = NSCharacterSet(charactersInString: String(firstComponentOrderingString) + String(lastComponentOrderingString))
-        componentOrdering = componentOrdering.stringByTrimmingCharactersInSet(characterSet).stringByTrimmingCharactersInSet(NSCharacterSet.punctuationCharacterSet()).stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+        let characterSet = NSMutableCharacterSet()
+        
+        characterSet.formUnionWithCharacterSet(NSCharacterSet(charactersInString: String(firstComponentOrderingString) +
+            String(lastComponentOrderingString)))
+        characterSet.formUnionWithCharacterSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+        characterSet.formUnionWithCharacterSet(NSCharacterSet.punctuationCharacterSet())
+        
+        componentOrdering = componentOrdering.stringByTrimmingCharactersInSet(characterSet)
 
         let remainingValue = componentOrdering[componentOrdering.startIndex.advancedBy(0)]
 

--- a/Pod/Classes/PIDatePicker.swift
+++ b/Pod/Classes/PIDatePicker.swift
@@ -180,7 +180,7 @@ public class PIDatePicker: UIControl, UIPickerViewDataSource, UIPickerViewDelega
         let lastComponentOrderingString = componentOrdering[componentOrdering.startIndex.advancedBy(componentOrdering.characters.count - 1)]
 
         let characterSet = NSCharacterSet(charactersInString: String(firstComponentOrderingString) + String(lastComponentOrderingString))
-        componentOrdering = componentOrdering.stringByTrimmingCharactersInSet(characterSet).stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+        componentOrdering = componentOrdering.stringByTrimmingCharactersInSet(characterSet).stringByTrimmingCharactersInSet(NSCharacterSet.punctuationCharacterSet()).stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
 
         let remainingValue = componentOrdering[componentOrdering.startIndex.advancedBy(0)]
 


### PR DESCRIPTION
The current code doesn't work with locales set to nb_NO. Since remainingValue will pick the first character from componentOrdering (which, after removing the first and second component, is ". MMMM", the enum lookup fails. By also trimming punctuations from componentOrdering, the correct remainingValue can be extracted before the lookup.
