### PR TITLE
Fix refreshComponentOrdering crash

### DIFF
--- a/Pod/Classes/PIDatePicker.swift
+++ b/Pod/Classes/PIDatePicker.swift
@@ -174,11 +174,12 @@ public class PIDatePicker: UIControl, UIPickerViewDataSource, UIPickerViewDelega
         Refreshes the ordering of components based on the current locale. Calling this function will not refresh the picker view.
     */
     private func refreshComponentOrdering() {
-        var componentOrdering = NSDateFormatter.dateFormatFromTemplate("yMMMMd", options: 0, locale: self.locale)!
-
+        guard var componentOrdering = NSDateFormatter.dateFormatFromTemplate("yMMMMd", options: 0, locale: self.locale) else {
+            return
+        }
+        
         let firstComponentOrderingString = componentOrdering[componentOrdering.startIndex.advancedBy(0)]
         let lastComponentOrderingString = componentOrdering[componentOrdering.startIndex.advancedBy(componentOrdering.characters.count - 1)]
-
         let characterSet = NSMutableCharacterSet()
         
         characterSet.formUnionWithCharacterSet(NSCharacterSet(charactersInString: String(firstComponentOrderingString) +
@@ -187,14 +188,17 @@ public class PIDatePicker: UIControl, UIPickerViewDataSource, UIPickerViewDelega
         characterSet.formUnionWithCharacterSet(NSCharacterSet.punctuationCharacterSet())
         
         componentOrdering = componentOrdering.stringByTrimmingCharactersInSet(characterSet)
-
         let remainingValue = componentOrdering[componentOrdering.startIndex.advancedBy(0)]
-
-        let firstComponent = PIDatePickerComponents(rawValue: firstComponentOrderingString)!
-        let secondComponent = PIDatePickerComponents(rawValue: remainingValue)!
-        let lastComponent = PIDatePickerComponents(rawValue: lastComponentOrderingString)!
-
-        self.datePickerComponentOrdering = [firstComponent, secondComponent, lastComponent]
+        
+        let firstComponent = PIDatePickerComponents(rawValue: firstComponentOrderingString)
+        let secondComponent = PIDatePickerComponents(rawValue: remainingValue)
+        let lastComponent = PIDatePickerComponents(rawValue: lastComponentOrderingString)
+        
+        guard let first = firstComponent, let second = secondComponent, let third = lastComponent else {
+            return
+        }
+        
+        self.datePickerComponentOrdering = [first, second, third]
     }
     
     /**


### PR DESCRIPTION
Removing force unwrapping should fix crash on `refreshComponentOrdering()` when nil value is inserted in Array.

```
Crashed: com.apple.main-thread
0  PIDatePicker                   0xcab014 PIDatePicker.(refreshComponentOrdering in _94F378CF051E2E8A839C000B83D205B6)() -> () (PIDatePicker.swift)
1  PIDatePicker                   0xcb64f4 specialized Character.init(_builtinExtendedGraphemeClusterLiteral : Builtin.RawPointer, byteSize : Builtin.Word, isASCII : Builtin.Int1) -> Character (PIDatePickerComponents.swift)
2  PIDatePicker                   0xcaa5cc @objc PIDatePicker.willMoveToSuperview(UIView?) -> () (PIDatePicker.swift:133)
```
