### PR TITLE
Fix PIDatePicker not resizing UIPickerView to full available width

### DIFF
--- a/Pod/Classes/PIDatePicker.swift
+++ b/Pod/Classes/PIDatePicker.swift
@@ -97,6 +97,7 @@ public class PIDatePicker: UIControl, UIPickerViewDataSource, UIPickerViewDelega
      */
     func commonInit() {
         self.translatesAutoresizingMaskIntoConstraints = false
+        self.pickerView.translatesAutoresizingMaskIntoConstraints = false
         
         self.pickerView.dataSource = self
         self.pickerView.delegate = self

--- a/Pod/Classes/PIDatePicker.swift
+++ b/Pod/Classes/PIDatePicker.swift
@@ -95,8 +95,7 @@ public class PIDatePicker: UIControl, UIPickerViewDataSource, UIPickerViewDelega
     /**
      Handles the common initialization amongst all init()
      */
-    func commonInit() {
-        self.translatesAutoresizingMaskIntoConstraints = false
+    func commonInit() {        
         self.pickerView.translatesAutoresizingMaskIntoConstraints = false
         
         self.pickerView.dataSource = self


### PR DESCRIPTION
I integrated `PIDatePicker` into my app, and the `UIPickerView` itself would not fill the full available width of `PIDatePicker` view. After some experimentation it turned out that also the `UIPickerView` needs  `translatesAutoresizingMaskIntoConstraints = false`. This resulted in both the picker filling the complete available width and being able to include it in a animation that animated the parent view. 

I think that without setting that property to false, the layout constraints do not have full effect on the picker.